### PR TITLE
Improve package scripts for running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,4 @@ install:
   - bower install
 
 script:
-  - ember try $EMBER_TRY_SCENARIO test && mocha --recursive node-tests/
+  - npm run test:ci

--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
   "scripts": {
     "build": "ember build",
     "start": "ember server",
-    "test": "ember try:testall"
+    "test": "mocha --recursive node-tests/",
+    "test:ember": "ember try:testall",
+    "test:all": "npm test && npm run test:ember",
+    "test:ci": "npm test && ember try $EMBER_TRY_SCENARIO test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This will improve the ergonomics of developing locally. Now the mocha tests will run with `npm test` since those are the primary tests for this addon.