### PR TITLE
Remove distill/filtering options

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/trentmwillis/ember-exam.svg)](https://travis-ci.org/trentmwillis/ember-exam)
 
-Ember Exam is an addon to allow you more control over how you run your tests. It provides the ability to randomize, split, distill, and parallelize your test suite by adding a more robust CLI command.
+Ember Exam is an addon to allow you more control over how you run your tests. It provides the ability to randomize, split, and parallelize your test suite by adding a more robust CLI command.
 
 It started as a way to help reduce flaky tests and encourage healthy test driven development. It's like [Head & Shoulders](http://www.headandshoulders.com/) for your tests!
 
@@ -19,18 +19,6 @@ $ ember exam --server
 ```
 
  The idea is that you should be able to replace `ember test` with `ember exam` and never look back.
-
-### Filtering
-
-**FEATURE IN PROGRESS**
-
-```bash
-$ ember exam --distill=<string|regex>
-```
-
-The default `filter` option only applies a filter in browser that is used by QUnit. This means all your tests are still loaded and parsed, but only a subset are run. Additionally, you can only use a simple string to filter on.
-
-The `distill` option filters the tests after build so that you only load and parse those tests that are being run. It also supports taking a regular expression string to match tests against for added flexibility.
 
 ### Randomization
 
@@ -84,7 +72,7 @@ _Note: You must be using Testem version `1.5.0` or greater for this feature to w
 
 ## Usage Constraints
 
-Since Ember Exam performs many of its functions by inspecting the Abstract Syntax Tree of your tests, it is bound by some constraints. Specifically, any task that involves identifying individual tests (e.g., distilling and randomizing tests) are currently limited to tests that follow a structure similar to:
+Since Ember Exam performs many of its functions by inspecting the Abstract Syntax Tree of your tests, it is bound by some constraints. Specifically, any task that involves identifying individual tests (e.g., randomizing individual tests) are currently limited to tests that follow a structure similar to:
 
 ```javascript
 import { module, test } from 'qunit';

--- a/lib/commands/exam.js
+++ b/lib/commands/exam.js
@@ -18,8 +18,7 @@ module.exports = TestCommand.extend({
     { name: 'weighted',     type: Boolean,                 description: 'Weights the type of tests to help equal splits.' },
     { name: 'parallel',     type: Boolean, default: false, description: 'Runs your split tests on parallel child processes.' },
     { name: 'random',       type: String,  default: false, description: 'Randomizes your modules and tests before running your test suite.' },
-    { name: 'seed',         type: Number,                  description: 'A starting value from which to randomize your tests.' },
-    { name: 'distill',      type: String,                  description: 'Filters your tests after build on a string or regex value.' }
+    { name: 'seed',         type: Number,                  description: 'A starting value from which to randomize your tests.' }
   ].concat(TestCommand.prototype.availableOptions),
 
   utils: {

--- a/lib/utils/tests-options-validator.js
+++ b/lib/utils/tests-options-validator.js
@@ -19,7 +19,7 @@ function TestsOptionsValidator(options) {
  */
 Object.defineProperty(TestsOptionsValidator.prototype, 'needsAST', {
   get: function _getNeedsAST() {
-    return this.shouldSplit || this.shouldRandomize || this.shouldFilter;
+    return this.shouldSplit || this.shouldRandomize;
   }
 });
 
@@ -90,23 +90,6 @@ Object.defineProperty(TestsOptionsValidator.prototype, 'shouldRandomize', {
 });
 
 /**
- * Determines if we should filter the tests and validates associated options
- * (`distill`).
- *
- * @public
- * @type {Boolean}
- */
-Object.defineProperty(TestsOptionsValidator.prototype, 'shouldFilter', {
-  get: function _getShouldFilter() {
-    var distill = this.options.distill;
-    if (typeof distill !== 'undefined' && !distill) {
-      throw new Error('You must specify either a normal string or a regex pattern for \'distill\'.');
-    }
-    return !!distill;
-  }
-});
-
-/**
  * Determines if we should run split tests in parallel and validates associated
  * options (`parallel`).
  *
@@ -114,7 +97,7 @@ Object.defineProperty(TestsOptionsValidator.prototype, 'shouldFilter', {
  * @type {Boolean}
  */
 Object.defineProperty(TestsOptionsValidator.prototype, 'shouldParallelize', {
-  get: function _getShouldFilter() {
+  get: function _getShouldParallelize() {
     var parallel = this.options.parallel;
 
     if (!parallel) {

--- a/lib/utils/tests-processor.js
+++ b/lib/utils/tests-processor.js
@@ -73,19 +73,8 @@ TestsProcessor.prototype._divideAST = function() {
  */
 TestsProcessor.prototype._processAST = function(validator) {
   // Order is important here
-  if (validator.shouldFilter) { this.filter(); }
   if (validator.shouldRandomize) { this.randomize(); }
   if (validator.shouldSplit) { this.split(); }
-};
-
-/**
- * Filters the tests and modules.
- *
- * @public
- * @return {Void}
- */
-TestsProcessor.prototype.filter = function() {
-  console.info('TODO: Support filtering. Pull requests welcome!');
 };
 
 /**

--- a/node-tests/unit/utils/tests-options-validator-test.js
+++ b/node-tests/unit/utils/tests-options-validator-test.js
@@ -14,32 +14,12 @@ describe('TestOptionsValidator', function() {
       assert.equal(validator.needsAST, true);
     });
 
-    it('returns true if shouldFilter is true', function() {
-      var validator = new TestOptionsValidator({ distill: 'filter' });
-      assert.equal(validator.needsAST, true);
-    });
-
     it('returns true if shouldSplit and shouldRandomize are true', function() {
       var validator = new TestOptionsValidator({ split: 2, random: '' });
       assert.equal(validator.needsAST, true);
     });
 
-    it('returns true if shouldSplit and shouldFilter are true', function() {
-      var validator = new TestOptionsValidator({ split: 2, distill: 'filter' });
-      assert.equal(validator.needsAST, true);
-    });
-
-    it('returns true if shouldRandomize and shouldFilter are true', function() {
-      var validator = new TestOptionsValidator({ random: '', distill: 'filter' });
-      assert.equal(validator.needsAST, true);
-    });
-
-    it('returns true if shouldSplit, shouldRandomize, and shouldFilter are true', function() {
-      var validator = new TestOptionsValidator({ split: 2, random: '', distill: 'filter' });
-      assert.equal(validator.needsAST, true);
-    });
-
-    it('returns false if shouldSplit, shouldRandomize, and shouldFilter are false', function() {
+    it('returns false if shouldSplit and shouldRandomize are false', function() {
       var validator = new TestOptionsValidator({});
       assert.equal(validator.needsAST, false);
     });
@@ -122,23 +102,6 @@ describe('TestOptionsValidator', function() {
     it('should return false if `random` is not used', function() {
       var validator = new TestOptionsValidator({});
       assert.equal(validator.shouldRandomize, false);
-    });
-  });
-
-  describe('shouldFilter', function() {
-    it('should return true if using `distill`', function() {
-      var validator = new TestOptionsValidator({ distill: '/some.*regex/' });
-      assert.equal(validator.shouldFilter, true);
-    });
-
-    it('should throw an error if using `distill` with a falsy value', function() {
-      var validator = new TestOptionsValidator({ distill: '' });
-      assert.throws(function() { validator.shouldFilter; }, /You must specify either a normal string or a regex pattern for 'distill'/);
-    });
-
-    it('should return false if not using `distill`', function() {
-      var validator = new TestOptionsValidator({});
-      assert.equal(validator.shouldFilter, false);
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-exam",
   "version": "0.2.1",
-  "description": "Run your tests with better filtering, randomization, splitting, and parallelization for beautiful tests.",
+  "description": "Run your tests with randomization, splitting, and parallelization for beautiful tests.",
   "directories": {
     "doc": "doc",
     "test": "tests"


### PR DESCRIPTION
Never implemented, but, as mentioned in #9, it should not be a concern of this addon:

> Distill should not be an option. The primary benefit here was to support filtering via regex, but this makes more sense at the test framework level. This was also introduced to QUnit in 1.21.