### PR TITLE
Revamp randomization option to defer to QUnit implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,18 +23,20 @@ $ ember exam --server
 ### Randomization
 
 ```bash
-$ ember exam --random=<''|'tests'|'modules'>
+$ ember exam --random[=<seed>]
 ```
 
-By default, the `random` option allows you to run your test modules in a random order. This is essentially the same as if you were you to randomize the structure of your test directory. You can also use `--random=modules` to achieve the same effect more explicitly.
-
-If you specify `--random=tests`, it will randomizes test modules and the tests within those modules. This means that the test modules will be randomly ordered and then the tests within them will be randomly ordered as well.
+The `random` option allows you to randomize the order in which your tests run. You can optionally specify a "seed" value from which to randomize your tests in order to reproduce results. The seed can be any string value. Regardless of whether you specify a seed or not, Ember Exam will log the seed value used for the randomization at the beginning of the test run:
 
 ```bash
-$ ember exam --random --seed=<num>
+$ ember exam --random
+$ Randomizing tests with seed: liv5d1ixkco6qlatl6o7mbo6r
+
+$ ember exam --random=this_is1337
+$ Randomizing tests with seed: this_is1337
 ```
 
-The `seed` option allows you to specify a starting value from which to randomize your test/module order. This allows reproduction of issues that occurred when running randomly. There are no bounds on what the seed value can be, though generated seeds are within the range of [0, 10000).
+_Note: You must be using QUnit version `1.23.0` or greater for this feature to work properly._
 
 ### Splitting
 

--- a/lib/commands/exam.js
+++ b/lib/commands/exam.js
@@ -17,8 +17,7 @@ module.exports = TestCommand.extend({
     { name: 'split-file',   type: Number,                  description: 'The number of the file to run after splitting.' },
     { name: 'weighted',     type: Boolean,                 description: 'Weights the type of tests to help equal splits.' },
     { name: 'parallel',     type: Boolean, default: false, description: 'Runs your split tests on parallel child processes.' },
-    { name: 'random',       type: String,  default: false, description: 'Randomizes your modules and tests before running your test suite.' },
-    { name: 'seed',         type: Number,                  description: 'A starting value from which to randomize your tests.' }
+    { name: 'random',       type: String,  default: false, description: 'Randomizes your modules and tests before running your test suite.' }
   ].concat(TestCommand.prototype.availableOptions),
 
   utils: {
@@ -45,7 +44,28 @@ module.exports = TestCommand.extend({
       }
     }
 
+    if (this.validator.shouldRandomize) {
+      this._randomize(commandOptions);
+    }
+
     return this._super.run.apply(this, arguments);
+  },
+
+  /**
+   * Adds a `seed` param to the `query` to support randomization through QUnit.
+   *
+   * @param {Object} commandOptions
+   * @return {Void}
+   */
+  _randomize: function(commandOptions) {
+    var random = commandOptions.random;
+    var query = commandOptions.query;
+    var seed = random !== '' ? random : Math.random().toString(36).slice(2);
+    var seedQuery = 'seed=' + seed;
+
+    this.ui.writeLine('Randomizing test with seed: ' + seed);
+
+    commandOptions.query = query ? query + '&' + seedQuery : seedQuery;
   },
 
   /**

--- a/lib/utils/array.js
+++ b/lib/utils/array.js
@@ -1,50 +1,6 @@
 'use strict';
 
 /**
- * Generates a random seed (just an integer), ranging from 0 to 10,000.
- * @return {Number}
- */
-function _generateSeed() {
-  return Math.floor(Math.random() * 10000);
-}
-
-/**
- * Creates a seeded random number generator. Very simplistic in implementation
- * but works for the purposes of randomizing order.
- * @param {Number} seed
- * @return {Function}
- */
-function _randomNumberGenerator(seed) {
-  /**
-   * Returns a random number in the range of [0,1].
-   * @return {Number}
-   */
-  return function _random() {
-    var x = Math.sin(seed++) * 10000;
-    return x - Math.floor(x);
-  }
-}
-
-/**
- * Randomly sorts an array in place. Can optionally provide a seed value to get
- * reproducible results. Returns the seed used to randomize the array.
- * @param {Array} array
- * @param {Number} seed
- * @return {Number}
- */
-function randomizeArray(array, seed) {
-  if (typeof seed !== 'number') {
-    seed = _generateSeed();
-  }
-
-  var randomNumber = _randomNumberGenerator(seed);
-
-  array.sort(function() { return 0.5 - randomNumber(); });
-
-  return seed;
-}
-
-/**
  * Splits an array into n number of roughly equal sized parts.
  * @param {Array} array
  * @param {Number} n
@@ -120,7 +76,6 @@ function moveArrayElement(array, from, to) {
 }
 
 module.exports = {
-  randomize: randomizeArray,
   split: splitArray,
   moveElement: moveArrayElement,
   weightedSplit: weightedArraySplit

--- a/lib/utils/tests-options-validator.js
+++ b/lib/utils/tests-options-validator.js
@@ -19,7 +19,7 @@ function TestsOptionsValidator(options) {
  */
 Object.defineProperty(TestsOptionsValidator.prototype, 'needsAST', {
   get: function _getNeedsAST() {
-    return this.shouldSplit || this.shouldRandomize;
+    return this.shouldSplit;
   }
 });
 
@@ -65,27 +65,14 @@ Object.defineProperty(TestsOptionsValidator.prototype, 'shouldSplit', {
 
 /**
  * Determines if we should randomize the tests and validates associated options
- * (`random` and `seed`).
+ * (`random`).
  *
  * @public
  * @type {Boolean}
  */
 Object.defineProperty(TestsOptionsValidator.prototype, 'shouldRandomize', {
   get: function _getShouldRandomize() {
-    var options = this.options;
-    var random = options.random = options.random === '' ? 'modules' : options.random;
-
-    if (random && random !== 'tests' && random !== 'modules') {
-      throw new Error('Valid options for \'random\' are \'tests\', \'modules\', or nothing.');
-    }
-
-    var seed = options.seed;
-
-    if (!random && typeof seed !== 'undefined') {
-      throw new Error('You specified a \'seed\' value but are not using \'random\' as well.');
-    }
-
-    return !!random;
+    return typeof this.options.random === 'string'
   }
 });
 

--- a/lib/utils/tests-processor.js
+++ b/lib/utils/tests-processor.js
@@ -73,60 +73,7 @@ TestsProcessor.prototype._divideAST = function() {
  */
 TestsProcessor.prototype._processAST = function(validator) {
   // Order is important here
-  if (validator.shouldRandomize) { this.randomize(); }
   if (validator.shouldSplit) { this.split(); }
-};
-
-/**
- * Randomizes the order of tests and modules.
- *
- * @public
- * @return {Void}
- */
-TestsProcessor.prototype.randomize = function() {
-  // Randomize the test modules
-  var seed = ArrayUtils.randomize(this.testModules, this.options.seed);
-
-  if (this.options.random === 'modules') {
-    console.info('Randomized test modules with seed:', seed);
-    return;
-  }
-
-  // Randomize the tests within each test module
-  this.testModules.forEach(function(group) {
-    var nodes = [];
-    recast.visit(group, {
-      visitMemberExpression: function(path) {
-        // Unfortunately, the heuristic for determining if an expression is
-        // actually a test is somewhat limited. We use the object and property
-        // names to see if it is a test call or not.
-        if (path.node.property.name === 'test' && TEST_OBJECTS.indexOf(path.node.object.name) !== -1) {
-          // Find the closest parent that is the actual expression of this test
-          var parent = path.parent;
-          while (parent.node.type !== 'ExpressionStatement') {
-            parent = parent.parent;
-          }
-
-          // Push the parent node into the nodes array
-          nodes.push(parent.node);
-
-          // Remove it from the AST
-          parent.prune();
-        }
-
-        this.traverse(path);
-      }
-    });
-
-    // Randomize the tests
-    ArrayUtils.randomize(nodes, seed);
-
-    // Get the body of the test module and concat the nodes back into it
-    var body = group.expression.arguments[2].body;
-    body.body = body.body.concat(nodes);
-  });
-
-  console.info('Randomized tests with seed:', seed);
 };
 
 /**

--- a/node-tests/unit/commands/exam-test.js
+++ b/node-tests/unit/commands/exam-test.js
@@ -28,7 +28,10 @@ describe('ExamCommand', function() {
 
       command = new ExamCommand({
         project: project,
-        tasks: tasks
+        tasks: tasks,
+        ui: {
+          writeLine: function() {}
+        }
       });
 
       superCall = { called: false };
@@ -73,7 +76,7 @@ describe('ExamCommand', function() {
       });
     });
 
-    it('should set \'splitFile\' to the query option', function() {
+    it('should set \'splitFile\' on the query option', function() {
       command.run({ split: 2, splitFile: 2 });
 
       assert.equal(superCall.options.query, 'splitFile=2');
@@ -84,6 +87,20 @@ describe('ExamCommand', function() {
       command.run({ split: 2, splitFile: 2, query: 'someQuery=derp&hidepassed' });
 
       assert.equal(superCall.options.query, 'someQuery=derp&hidepassed&splitFile=2');
+      assert.equal(superCall.called, true);
+    });
+
+    it('should set \'seed=1337\' on the query option', function() {
+      command.run({ random: '1337' });
+
+      assert.equal(superCall.options.query, 'seed=1337');
+      assert.equal(superCall.called, true);
+    });
+
+    it('should append \'seed=1337\' to the query option', function() {
+      command.run({ random: '1337', query: 'someQuery=derp&hidepassed' });
+
+      assert.equal(superCall.options.query, 'someQuery=derp&hidepassed&seed=1337');
       assert.equal(superCall.called, true);
     });
   });

--- a/node-tests/unit/utils/array-test.js
+++ b/node-tests/unit/utils/array-test.js
@@ -3,23 +3,6 @@ var assert = require('assert');
 var ArrayUtils = require('../../../lib/utils/array');
 
 describe('ArrayUtils', function() {
-  describe('randomize', function() {
-    it('should randomize an array with a passed in seed', function() {
-      var array = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 0 ];
-      var seed = ArrayUtils.randomize(array, 10);
-
-      assert.deepEqual(array, [ 3, 1, 2, 5, 7, 4, 8, 0, 9, 6 ]);
-      assert.equal(seed, 10);
-    });
-
-    it('should randomize an array with a generated seed', function() {
-      var array = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 0 ];
-      var seed = ArrayUtils.randomize(array);
-
-      assert.equal(typeof seed === 'number', true);
-    });
-  });
-
   describe('split', function() {
     it('should generate equal sized arrays with a nice fraction', function() {
       var array = [ 'a', 'b' ];

--- a/node-tests/unit/utils/tests-options-validator-test.js
+++ b/node-tests/unit/utils/tests-options-validator-test.js
@@ -9,17 +9,7 @@ describe('TestOptionsValidator', function() {
       assert.equal(validator.needsAST, true);
     });
 
-    it('returns true if shouldRandomize is true', function() {
-      var validator = new TestOptionsValidator({ random: '' });
-      assert.equal(validator.needsAST, true);
-    });
-
-    it('returns true if shouldSplit and shouldRandomize are true', function() {
-      var validator = new TestOptionsValidator({ split: 2, random: '' });
-      assert.equal(validator.needsAST, true);
-    });
-
-    it('returns false if shouldSplit and shouldRandomize are false', function() {
+    it('returns false if shouldSplit is false', function() {
       var validator = new TestOptionsValidator({});
       assert.equal(validator.needsAST, false);
     });
@@ -68,35 +58,19 @@ describe('TestOptionsValidator', function() {
   });
 
   describe('shouldRandomize', function() {
-    it('should return true if `random` is set to \'tests\'', function() {
-      var validator = new TestOptionsValidator({ random: 'tests' });
-      assert.equal(validator.shouldRandomize, true);
-    });
-
-    it('should return true if `random` is set to \'modules\'', function() {
-      var validator = new TestOptionsValidator({ random: 'modules' });
-      assert.equal(validator.shouldRandomize, true);
-    });
-
-    it('should default `random` to \'modules\' if used without a value', function() {
+    it('should return true if `random` is an empty string', function() {
       var validator = new TestOptionsValidator({ random: '' });
       assert.equal(validator.shouldRandomize, true);
-      assert.equal(validator.options.random, 'modules');
     });
 
-    it('should throw an error if `random` is a non-supported value', function() {
-      var validator = new TestOptionsValidator({ random: 'herp' });
-      assert.throws(function() { validator.shouldRandomize; }, /Valid options for 'random' are 'tests', 'modules', or nothing/);
-    });
-
-    it('should return true if `random` is used with `seed`', function() {
-      var validator = new TestOptionsValidator({ random: '', seed: 10 });
+    it('should return true if `random` is set to a string', function() {
+      var validator = new TestOptionsValidator({ random: '1337' });
       assert.equal(validator.shouldRandomize, true);
     });
 
-    it('should throw an error if `seed` is used without `random`', function() {
-      var validator = new TestOptionsValidator({ seed: 10 });
-      assert.throws(function() { validator.shouldRandomize; }, /You specified a 'seed' value but are not using 'random' as well/);
+    it('should return false if `random` is a non-string', function() {
+      var validator = new TestOptionsValidator({ random: true });
+      assert.equal(validator.shouldRandomize, false);
     });
 
     it('should return false if `random` is not used', function() {


### PR DESCRIPTION
Addressing part of #9:

> Randomization of individual tests should be a test framework concern. This is because ensuring tests are running appropriate hooks is more correctly done at that level.

This PR essentially removes the AST randomization we were doing in favor of simply setting a URL param that tells QUnit to randomly order the tests.