### PR TITLE
Add option to specify testem-root

### DIFF
--- a/lib/commands/exam.js
+++ b/lib/commands/exam.js
@@ -17,7 +17,8 @@ module.exports = TestCommand.extend({
     { name: 'split-file',   type: Number,                  description: 'The number of the file to run after splitting.' },
     { name: 'weighted',     type: Boolean,                 description: 'Weights the type of tests to help equal splits.' },
     { name: 'parallel',     type: Boolean, default: false, description: 'Runs your split tests on parallel child processes.' },
-    { name: 'random',       type: String,  default: false, description: 'Randomizes your modules and tests before running your test suite.' }
+    { name: 'random',       type: String,  default: false, description: 'Randomizes your modules and tests before running your test suite.' },
+    { name: 'testem-root',  type: String,  default: '',    description: 'The path relative to the output directory from which to start Testem.' }
   ].concat(TestCommand.prototype.availableOptions),
 
   utils: {

--- a/lib/utils/tests-processor.js
+++ b/lib/utils/tests-processor.js
@@ -33,7 +33,7 @@ function TestsProcessor(validator) {
   this.options = validator.options;
 
   // Grab the tests file and parse it into an AST
-  this.testsFilePath = path.resolve(this.options.outputPath, 'assets/tests.js');
+  this.testsFilePath = path.resolve(this.options.outputPath, this.options.testemRoot, 'assets/tests.js');
   this.ast = parseASTFromFile(this.testsFilePath);
 
   this._divideAST();
@@ -148,7 +148,7 @@ TestsProcessor.prototype._writeTestFile = function(content, name) {
   ast.program.body.push(this.requireStatement);
 
   // Write the AST to a file
-  var filePath = path.resolve(this.options.outputPath, 'assets', name);
+  var filePath = path.resolve(this.options.outputPath, this.options.testemRoot, 'assets', name);
   fs.writeFileSync(filePath, recast.print(ast).code);
 };
 


### PR DESCRIPTION
Useful if your build gets moved to a non-default location. Won't be needed once we get test-loader to do the splitting though.