### PR TITLE
Add support for splitting via test-loader instead of AST

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,5 +7,9 @@ module.exports = {
 
   includedCommands: function() {
     return require('./lib/commands');
+  },
+
+  included: function(app) {
+    app.import('vendor/ember-exam/test-loader.js', { type: 'test' });
   }
 };

--- a/lib/commands/exam.js
+++ b/lib/commands/exam.js
@@ -18,7 +18,8 @@ module.exports = TestCommand.extend({
     { name: 'weighted',     type: Boolean,                 description: 'Weights the type of tests to help equal splits.' },
     { name: 'parallel',     type: Boolean, default: false, description: 'Runs your split tests on parallel child processes.' },
     { name: 'random',       type: String,  default: false, description: 'Randomizes your modules and tests before running your test suite.' },
-    { name: 'testem-root',  type: String,  default: '',    description: 'The path relative to the output directory from which to start Testem.' }
+    { name: 'testem-root',  type: String,  default: '',    description: 'The path relative to the output directory from which to start Testem.' },
+    { name: 'use-ast',      type: Boolean, default: true,  description: 'Whether to split tests using the AST during build or test-loader at runtime.' },
   ].concat(TestCommand.prototype.availableOptions),
 
   utils: {
@@ -36,12 +37,16 @@ module.exports = TestCommand.extend({
 
     if (this.validator.needsAST) {
       this._patchBuildTask();
+    }
 
-      // If we're running specific file of tests, add it to the query.
-      var splitFile = commandOptions.splitFile;
-      if (this.validator.shouldSplit && splitFile) {
-        var query = commandOptions.query;
-        commandOptions.query = query ? query + '&splitFile=' + splitFile : 'splitFile=' + splitFile;
+    // If we're running specific file of tests, add it to the query.
+    var splitFile = commandOptions.splitFile;
+    if (this.validator.shouldSplit && splitFile) {
+      var query = commandOptions.query;
+      commandOptions.query = query ? query + '&splitFile=' + splitFile : 'splitFile=' + splitFile;
+
+      if (!commandOptions.useAst) {
+        commandOptions.query += '&split=' + commandOptions.split;
       }
     }
 
@@ -89,13 +94,19 @@ module.exports = TestCommand.extend({
       if (testPage) {
         containsQueryString = testPage.indexOf('?') > -1;
         testPageJoinChar = containsQueryString ? '&' : '?';
-        baseUrl = testPage + testPageJoinChar + 'splitFile='
+        baseUrl = testPage + testPageJoinChar + 'splitFile=';
       }
 
       config.testPage = [];
 
       for (var i = 0; i < count; i++) {
-        config.testPage.push(baseUrl + (i + 1));
+        var url = baseUrl + (i + 1);
+
+        if (!commandOptions.useAst) {
+          url += '&split=' + count;
+        }
+
+        config.testPage.push(url);
       }
     }
 

--- a/lib/utils/tests-options-validator.js
+++ b/lib/utils/tests-options-validator.js
@@ -19,7 +19,7 @@ function TestsOptionsValidator(options) {
  */
 Object.defineProperty(TestsOptionsValidator.prototype, 'needsAST', {
   get: function _getNeedsAST() {
-    return this.shouldSplit;
+    return this.shouldSplit && this.options.useAst;
   }
 });
 

--- a/node-tests/unit/commands/exam-test.js
+++ b/node-tests/unit/commands/exam-test.js
@@ -51,7 +51,7 @@ describe('ExamCommand', function() {
     });
 
     it('should defer to super after patching the build task', function() {
-      command.run({ split: 2 });
+      command.run({ split: 2, useAst: true });
 
       assert.notEqual(originalBuildRun, command.tasks.Build.prototype.run);
       assert.equal(superCall.called, true);
@@ -67,7 +67,7 @@ describe('ExamCommand', function() {
         };
       };
 
-      command.run({ split: 2 });
+      command.run({ split: 2, useAst: true });
 
       var build = new command.tasks.Build();
       build.run({ outputPath: 'dist' }).then(function() {
@@ -79,14 +79,14 @@ describe('ExamCommand', function() {
     it('should set \'splitFile\' on the query option', function() {
       command.run({ split: 2, splitFile: 2 });
 
-      assert.equal(superCall.options.query, 'splitFile=2');
+      assert.equal(superCall.options.query, 'splitFile=2&split=2');
       assert.equal(superCall.called, true);
     });
 
     it('should append \'splitFile\' to the query option', function() {
       command.run({ split: 2, splitFile: 2, query: 'someQuery=derp&hidepassed' });
 
-      assert.equal(superCall.options.query, 'someQuery=derp&hidepassed&splitFile=2');
+      assert.equal(superCall.options.query, 'someQuery=derp&hidepassed&splitFile=2&split=2');
       assert.equal(superCall.called, true);
     });
 
@@ -129,7 +129,8 @@ describe('ExamCommand', function() {
     it('should modify the config to have multiple test pages', function() {
       var config = generateConfig({
         parallel: true,
-        split: 2
+        split: 2,
+        useAst: true
       });
 
       assert.deepEqual(config.testPage, [
@@ -152,7 +153,8 @@ describe('ExamCommand', function() {
         parallel: true,
         split: 2,
         query: 'foo=bar',
-        'test-page': 'tests.html'
+        'test-page': 'tests.html',
+        useAst: true
       });
 
       assert.deepEqual(config.testPage, [

--- a/node-tests/unit/utils/tests-options-validator-test.js
+++ b/node-tests/unit/utils/tests-options-validator-test.js
@@ -4,8 +4,8 @@ var TestOptionsValidator = require('../../../lib/utils/tests-options-validator')
 
 describe('TestOptionsValidator', function() {
   describe('needsAST', function() {
-    it('returns true if shouldSplit is true', function() {
-      var validator = new TestOptionsValidator({ split: 2 });
+    it('returns true if shouldSplit and useAst are true', function() {
+      var validator = new TestOptionsValidator({ split: 2, useAst: true });
       assert.equal(validator.needsAST, true);
     });
 

--- a/vendor/ember-exam/test-loader.js
+++ b/vendor/ember-exam/test-loader.js
@@ -1,0 +1,56 @@
+/* globals jQuery, QUnit, require, requirejs */
+
+jQuery(document).ready(function() {
+  var params = QUnit.urlParams;
+  var split = params.split;
+  var file = params.splitFile;
+
+  if (!split || !file) {
+    return;
+  }
+
+  var TestLoaderModule = require('ember-cli/test-loader');
+  var TestLoader = TestLoaderModule['default'];
+
+  var _super = {
+    require: TestLoader.prototype.require,
+    unsee: TestLoader.prototype.unsee,
+    loadModules: TestLoader.prototype.loadModules,
+  };
+
+  // "Require" the module by adding it to the array of test modules to load
+  TestLoader.prototype.require = function _require(name) {
+    this._testModules.push(name);
+  };
+
+  // Make unsee a no-op
+  TestLoader.prototype.unsee = function _unsee() {};
+
+  TestLoader.prototype.loadModules = function _loadSplitModules() {
+    this._testModules = [];
+
+    _super.loadModules.apply(this, arguments);
+
+    var splitModules = splitTestModules(this._testModules);
+
+    splitModules.forEach(function(moduleName) {
+      _super.require.call(this, moduleName);
+      _super.unsee.call(this, moduleName);
+    });
+  };
+
+  function splitTestModules(modules) {
+    var length = modules.length;
+    var groups = [];
+
+    for (var i = 0; i < length; i++) {
+      if (i < split) {
+        groups[i] = [];
+      }
+
+      groups[i % split].push(modules[i]);
+    }
+
+    return groups[file-1];
+  }
+});


### PR DESCRIPTION
Usage is by simply doing `ember exam --split=8 --use-ast=false`

Initial attempt at addressing #13, #14, and #15. It's hacky right now, but it'll be much better once Ember-CLI 2.7 is released with the new NPM module for ember-cli-test-loader.