### PR TITLE
Fix 0.4.2 regressions

### DIFF
--- a/tests/unit/test-loader-test.js
+++ b/tests/unit/test-loader-test.js
@@ -74,6 +74,20 @@ test('loads modules from the first partition by default', function(assert) {
   ]);
 });
 
+test('handles params as strings', function(assert) {
+  QUnit.urlParams = {
+    _partition: '3',
+    _split: '4',
+  };
+
+  this.TestLoader.load();
+
+  assert.deepEqual(this.requiredModules, [
+    'test-3-test.jshint',
+    'test-3-test',
+  ]);
+});
+
 test('throws an error if splitting less than one', function(assert) {
   QUnit.urlParams = {
     _split: 0,

--- a/vendor/ember-exam/test-loader.js
+++ b/vendor/ember-exam/test-loader.js
@@ -27,8 +27,11 @@ jQuery(document).ready(function() {
 
   TestLoader.prototype.loadModules = function _loadSplitModules() {
     var params = QUnit.urlParams;
-    var split = typeof params._split === 'number' ? params._split : 1;
-    var partition = typeof params._partition === 'number' ? params._partition : 1;
+    var split = parseInt(params._split, 10);
+    var partition = parseInt(params._partition, 10);
+
+    split = isNaN(split) ? 1 : split;
+    partition = isNaN(partition) ? 1 : partition;
 
     var testLoader = this;
 

--- a/vendor/ember-exam/test-loader.js
+++ b/vendor/ember-exam/test-loader.js
@@ -4,7 +4,7 @@ jQuery(document).ready(function() {
   // Add the partition number for better debugging when reading the reporter
   if (window.Testem) {
     Testem.on('test-result', function prependPartition(test) {
-      test.name = 'Exam Partition #' + QUnit.urlParams.partition + ' - ' + test.name;
+      test.name = 'Exam Partition #' + QUnit.urlParams._partition + ' - ' + test.name;
     });
   }
 


### PR DESCRIPTION
This PR fixes #27.

@trentmwillis' suspicions were correct. The two issues here were:
* `partition` typo, should have been `_partition`
* `_split` and `_partition` params were being treated as strings. Attempt to convert.

The added regression test should fail without the second commit, and pass with it included. Unfortunately, I can't think of a great way to test the `partition` typo at the moment. It seems preferable to just get these fixes in for now.

I'm happy to make modifications to the PR if you see any improvements that can be made.