### PR TITLE
Make requires lazy where possible

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,13 +2,11 @@
 
 'use strict';
 
-var Commands = require('./lib/commands');
-
 module.exports = {
   name: 'ember-exam',
 
   includedCommands: function() {
-    return Commands;
+    return require('./lib/commands');
   },
 
   included: function(app) {

--- a/lib/commands/exam.js
+++ b/lib/commands/exam.js
@@ -2,8 +2,6 @@
 
 var TestCommand = require('ember-cli/lib/commands/test');
 
-var TestsOptionsValidator = require('../utils/tests-options-validator');
-
 function addToQuery(query, param, value) {
   if (!value) {
     return query;
@@ -39,8 +37,16 @@ module.exports = TestCommand.extend({
     { name: 'random',       type: String,  default: false, description: 'Randomizes your modules and tests while running your test suite.' }
   ].concat(TestCommand.prototype.availableOptions),
 
-  utils: {
-    Validator: TestsOptionsValidator
+  /**
+   * Creates an options validator object.
+   *
+   * @private
+   * @param {Object} options
+   * @return {TestOptionsValidator}
+   */
+  _createValidator: function(options) {
+    var Validator = require('../utils/tests-options-validator');
+    return new Validator(options);
   },
 
   /**
@@ -49,7 +55,7 @@ module.exports = TestCommand.extend({
    * @override
    */
   run: function(commandOptions) {
-    this.validator = new this.utils.Validator(commandOptions);
+    this.validator = this._createValidator(commandOptions);
 
     if (this.validator.shouldSplit) {
       commandOptions.query = addToQuery(commandOptions.query, '_split', commandOptions.split);

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var ExamCommand = require('./exam');
-
 module.exports = {
-  'exam': ExamCommand
+  'exam': require('./exam')
 };


### PR DESCRIPTION
Addressing #34.

Unfortunately, I think the bulk of slowness comes from [requiring the Test Command](https://github.com/trentmwillis/ember-exam/blob/master/lib/commands/exam.js#L3), which I can't do much about, but at least this way it only gets required when `includedCommands` also runs.

cc @stefanpenner