### PR TITLE
Temporarily undocument `--weighted`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ $ ember exam --split=<num> --partition=<num>
 
 The `partition` option allows you to specify which test group to run after using the `split` option. It is one-indexed, so if you specifiy a split of 3, the last group you could run is 3 as well.
 
-```bash
+<!--```bash
 $ ember exam --split=<num> --weighted
 ```
 
-The `weighted` option splits tests by weighting them according to type; `acceptance` tests weigh more than `unit` tests weigh more than `jshint` tests. This helps make sure the various test groupings run in similar amounts of time.
+The `weighted` option splits tests by weighting them according to type; `acceptance` tests weigh more than `unit` tests weigh more than `jshint` tests. This helps make sure the various test groupings run in similar amounts of time. -->
 
 #### Split Test Parallelization
 


### PR DESCRIPTION
It had me confused if it worked or not. I propose to hide it until #31 lands.