### PR TITLE
Support specifying multiple partitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,18 @@ ok 3 PhantomJS 1.9 - Exam Partition #2 - some other test
 
 You can also combine the `parallel` option with the `partition` option to split tests, and then recombine partitions into parallel runs. This would, for example, allow you to run tests in multiple CI containers and have each CI container parallelize its list of tests.
 
+For example, if you wanted to run your tests across two containers, but have one of them run twice as many tests as the other, and run them in parallel, you could do this:
+
+```bash
+# container 1
+ember exam --split=3 --partition=1 --partition=2 --parallel
+```
+
+```bash
+# container 2
+ember exam --split=3 --partition=3
+```
+
 Ember Exam will respect the `parallel` setting of your [Testem config file](https://github.com/testem/testem/blob/master/docs/config_file.md#config-level-options) while running tests in parallel. _Note that the default value for `parallel` in Testem is 1, which means you'll need a non-default value to actually see parallel behavior._
 
 _Note: You must be using Testem version `1.5.0` or greater for this feature to work properly._

--- a/README.md
+++ b/README.md
@@ -74,7 +74,11 @@ The `split` option allows you to specify a number of partitions greater than one
 $ ember exam --split=<num> --partition=<num>
 ```
 
-The `partition` option allows you to specify which test group to run after using the `split` option. It is one-indexed, so if you specify a split of 3, the last group you could run is 3 as well.
+The `partition` option allows you to specify which test group to run after using the `split` option. It is one-indexed, so if you specify a split of 3, the last group you could run is 3 as well. You can also run multiple partitions, e.g.:
+
+```bash
+$ ember exam --split=4 --partition=1 --partition=2
+```
 
 _Note: Ember Exam splits test by modifying the Ember-CLI `TestLoader`, which means that tests are split up according to AMD modules, so it is possible to have unbalanced partitions. For more info, see [issue #60](https://github.com/trentmwillis/ember-exam/issues/60)._
 
@@ -97,6 +101,8 @@ ok 1 PhantomJS 1.9 - Exam Partition #1 - some test
 ok 2 PhantomJS 1.9 - Exam Partition #3 - some other other test
 ok 3 PhantomJS 1.9 - Exam Partition #2 - some other test
 ```
+
+You can also combine the `parallel` option with the `partition` option to split tests, and then recombine partitions into parallel runs. This would, for example, allow you to run tests in multiple CI containers and have each CI container parallelize its list of tests.
 
 Ember Exam will respect the `parallel` setting of your [Testem config file](https://github.com/testem/testem/blob/master/docs/config_file.md#config-level-options) while running tests in parallel. _Note that the default value for `parallel` in Testem is 1, which means you'll need a non-default value to actually see parallel behavior._
 

--- a/lib/commands/exam.js
+++ b/lib/commands/exam.js
@@ -34,7 +34,7 @@ module.exports = TestCommand.extend({
 
   availableOptions: [
     { name: 'split',        type: Number,                  description: 'A number of files to split your tests across.' },
-    { name: 'partition',    type: Number,                  description: 'The number of the partition to run after splitting.' },
+    { name: 'partition',    type: [Array, String],         description: 'The number of the partition(s) to run after splitting.' },
     { name: 'weighted',     type: Boolean,                 description: 'Weights the type of tests to help equal splits.' },
     { name: 'parallel',     type: Boolean, default: false, description: 'Runs your split tests on parallel child processes.' },
     { name: 'random',       type: String,  default: false, description: 'Randomizes your modules and tests while running your test suite.' }
@@ -63,9 +63,13 @@ module.exports = TestCommand.extend({
     if (this.validator.shouldSplit) {
       commandOptions.query = addToQuery(commandOptions.query, '_split', commandOptions.split);
 
-      // Ignore the partition option when paralleling
+      // Ignore the partition option when paralleling (we'll fill it in later)
       if (!this.validator.shouldParallelize) {
-        commandOptions.query = addToQuery(commandOptions.query, '_partition', commandOptions.partition);
+        var partitions = commandOptions.partition;
+        if (partitions) {
+          partitions = partitions.join(',');
+        }
+        commandOptions.query = addToQuery(commandOptions.query, '_partitions', partitions);
       }
 
       commandOptions.query = addToQuery(commandOptions.query, '_weighted', commandOptions.weighted);
@@ -107,14 +111,22 @@ module.exports = TestCommand.extend({
       // use it as the baseUrl for the parallelized test pages
       var baseUrl = config.testPage || this._getTestPage(commandOptions.configFile);
       var count = commandOptions.split;
+      var partitions = commandOptions.partition;
+
+      if (!partitions) {
+        partitions = [];
+        for (var i = 0; i < commandOptions.split; i++) {
+          partitions.push(i + 1);
+        }
+      }
 
       if (Array.isArray(baseUrl)) {
         var command = this;
         config.testPage = baseUrl.reduce(function(testPages, baseUrl) {
-          return testPages.concat(command._generateTestPages(baseUrl, count));
+          return testPages.concat(command._generateTestPages(baseUrl, partitions, count));
         }, []);
       } else {
-        config.testPage = this._generateTestPages(baseUrl, count);
+        config.testPage = this._generateTestPages(baseUrl, partitions, count);
       }
     }
 
@@ -144,18 +156,20 @@ module.exports = TestCommand.extend({
 
   /**
    * Generates the test pages to use for parallel runs. For a given baseUrl,
-   * it appends the split count and a parition number as query params.
+   * it appends the total split count and the partition numbers each page is
+   * running as query params.
    *
    * @param {String} baseUrl
+   * @param {Array} partitions
    * @param {Number} count
    * @return {Array<String>} testPages
    */
-  _generateTestPages: function(baseUrl, count) {
+  _generateTestPages: function(baseUrl, partitions, count) {
     var splitUrl = addToUrl(baseUrl, '_split', count);
     var testPages = [];
 
-    for (var i = 0; i < count; i++) {
-      var url = addToUrl(splitUrl, '_partition', i + 1);
+    for (var i = 0; i < partitions.length; i++) {
+      var url = addToUrl(splitUrl, '_partitions', partitions[i]);
       testPages.push(url);
     }
 

--- a/lib/commands/exam.js
+++ b/lib/commands/exam.js
@@ -67,9 +67,10 @@ module.exports = TestCommand.extend({
       if (!this.validator.shouldParallelize) {
         var partitions = commandOptions.partition;
         if (partitions) {
-          partitions = partitions.join(',');
+          for (var i = 0; i < partitions.length; i++) {
+            commandOptions.query = addToQuery(commandOptions.query, '_partition', partitions[i]);
+          }
         }
-        commandOptions.query = addToQuery(commandOptions.query, '_partitions', partitions);
       }
 
       commandOptions.query = addToQuery(commandOptions.query, '_weighted', commandOptions.weighted);
@@ -160,7 +161,7 @@ module.exports = TestCommand.extend({
    * running as query params.
    *
    * @param {String} baseUrl
-   * @param {Array} partitions
+   * @param {Array<Number>} partitions
    * @param {Number} count
    * @return {Array<String>} testPages
    */
@@ -169,7 +170,7 @@ module.exports = TestCommand.extend({
     var testPages = [];
 
     for (var i = 0; i < partitions.length; i++) {
-      var url = addToUrl(splitUrl, '_partitions', partitions[i]);
+      var url = addToUrl(splitUrl, '_partition', partitions[i]);
       testPages.push(url);
     }
 

--- a/lib/commands/exam.js
+++ b/lib/commands/exam.js
@@ -34,7 +34,7 @@ module.exports = TestCommand.extend({
 
   availableOptions: [
     { name: 'split',        type: Number,                  description: 'A number of files to split your tests across.' },
-    { name: 'partition',    type: [Array, String],         description: 'The number of the partition(s) to run after splitting.' },
+    { name: 'partition',    type: [Array, Number],         description: 'The number of the partition(s) to run after splitting.' },
     { name: 'weighted',     type: Boolean,                 description: 'Weights the type of tests to help equal splits.' },
     { name: 'parallel',     type: Boolean, default: false, description: 'Runs your split tests on parallel child processes.' },
     { name: 'random',       type: String,  default: false, description: 'Randomizes your modules and tests while running your test suite.' }

--- a/lib/utils/tests-options-validator.js
+++ b/lib/utils/tests-options-validator.js
@@ -41,13 +41,25 @@ Object.defineProperty(TestsOptionsValidator.prototype, 'shouldSplit', {
 });
 
 /**
- * Determines if the specified partitions value makes sense for a given split.
+ * Validates the specified partitions
  *
  * @private
  * @param {Array} partitions
  * @param {Number} split
  */
 function validatePartitions(partitions, split) {
+  validatePartitionSplit(partitions, split);
+  validatePartitionsUnique(partitions);
+}
+
+/**
+ * Determines if the specified partitions value makes sense for a given split.
+ *
+ * @private
+ * @param {Array} partitions
+ * @param {Number} split
+ */
+function validatePartitionSplit(partitions, split) {
   if (!split) {
     throw new Error('You must specify a \'split\' value in order to use \'partition\'.');
   }
@@ -62,14 +74,23 @@ function validatePartitions(partitions, split) {
       throw new Error('You must specify \'partition\' values that are less than or equal to your \'split\' value.');
     }
   }
+}
 
+/**
+ * Ensures that there is no partition listed twice
+ *
+ * @private
+ * @param {Array} partitions
+ */
+function validatePartitionsUnique(partitions) {
   partitions = partitions.sort();
-  for (i = 0; i < partitions.length - 1; i++) {
+  for (var i = 0; i < partitions.length - 1; i++) {
     if (partitions[i] === partitions[i + 1]) {
       throw new Error('You cannot specify the same partition twice.');
     }
   }
 }
+
 
 /**
  * Determines if we should randomize the tests and validates associated options

--- a/lib/utils/tests-options-validator.js
+++ b/lib/utils/tests-options-validator.js
@@ -91,7 +91,6 @@ function validatePartitionsUnique(partitions) {
   }
 }
 
-
 /**
  * Determines if we should randomize the tests and validates associated options
  * (`random`).

--- a/lib/utils/tests-options-validator.js
+++ b/lib/utils/tests-options-validator.js
@@ -26,10 +26,10 @@ Object.defineProperty(TestsOptionsValidator.prototype, 'shouldSplit', {
       throw new Error('You must specify a number of files greater than 1 to split your tests across.');
     }
 
-    var partition = options.partition;
+    var partitions = options.partition;
 
-    if (typeof partition !== 'undefined') {
-      validatePartition(partition, split);
+    if (typeof partitions !== 'undefined') {
+      validatePartitions(partitions, split);
     }
 
     if (options.weighted && !split) {
@@ -41,23 +41,33 @@ Object.defineProperty(TestsOptionsValidator.prototype, 'shouldSplit', {
 });
 
 /**
- * Determines if the specified partition value makes sense for a given split.
+ * Determines if the specified partitions value makes sense for a given split.
  *
  * @private
- * @param {Number} partition
+ * @param {Array} partitions
  * @param {Number} split
  */
-function validatePartition(partition, split) {
+function validatePartitions(partitions, split) {
   if (!split) {
     throw new Error('You must specify a \'split\' value in order to use \'partition\'.');
   }
 
-  if (partition < 1) {
-    throw new Error('Split tests are one-indexed, so you must specify a partition greater than or equal to 1.');
+  for (var i = 0; i < partitions.length; i++) {
+    var partition = partitions[i];
+    if (partition < 1) {
+      throw new Error('Split tests are one-indexed, so you must specify partition values greater than or equal to 1.');
+    }
+
+    if (partition > split) {
+      throw new Error('You must specify \'partition\' values that are less than or equal to your \'split\' value.');
+    }
   }
 
-  if (partition > split) {
-    throw new Error('You must specify a \'partition\' value that is less than or equal to your \'split\' value.');
+  partitions = partitions.sort();
+  for (i = 0; i < partitions.length - 1; i++) {
+    if (partitions[i] === partitions[i + 1]) {
+      throw new Error('You cannot specify the same partition twice.');
+    }
   }
 }
 
@@ -91,10 +101,6 @@ Object.defineProperty(TestsOptionsValidator.prototype, 'shouldParallelize', {
 
     if (!this.shouldSplit) {
       throw new Error('You must specify the `split` option in order to run your tests in parallel.');
-    }
-
-    if (typeof this.options.partition !== 'undefined') {
-      console.info('Ignoring `partition` option due to running split tests in parallel.');
     }
 
     return true;

--- a/node-tests/acceptance/exam-test.js
+++ b/node-tests/acceptance/exam-test.js
@@ -11,7 +11,7 @@ function getNumberOfTests(str) {
   return match ? parseInt(match[1], 10) : 0;
 }
 
-var TOTAL_NUM_TESTS = 40;
+var TOTAL_NUM_TESTS = 44;
 
 describe('Acceptance | Exam Command', function() {
   this.timeout(300000);
@@ -30,11 +30,11 @@ describe('Acceptance | Exam Command', function() {
 
   function assertPartitions(output, good, bad) {
     good.forEach(function(partition) {
-      assert.ok(contains(output, 'Exam Partition #' + partition), 'output has partition #' + partition);
+      assert.ok(contains(output, 'Exam Partition #' + partition + ' '), 'output has partition #' + partition);
     });
 
     (bad || []).forEach(function(partition) {
-      assert.ok(!contains(output, 'Exam Partition #' + partition), 'output does not have partition #' + partition);
+      assert.ok(!contains(output, 'Exam Partition #' + partition + ' '), 'output does not have partition #' + partition);
     });
   }
 
@@ -79,10 +79,17 @@ describe('Acceptance | Exam Command', function() {
         });
       });
 
+      it('splits the test suite and runs multiple specified partitions', function(done) {
+        exec('ember exam --split 3 --partition 1 --partition 3 --path acceptance-dist', function(_, stdout) {
+          assertSomePartitions(stdout, [ '1,3' ], [ 1, 2, 3 ]);
+          done();
+        });
+      });
+
       it('errors when running an invalid partition', function(done) {
         execError(
           'ember exam --split 3 --partition 4 --path acceptance-dist',
-          'You must specify a \'partition\' value that is less than or equal to your \'split\' value.',
+          'You must specify \'partition\' values that are less than or equal to your \'split\' value.',
           done
         );
       });
@@ -104,10 +111,9 @@ describe('Acceptance | Exam Command', function() {
         });
       });
 
-      it('ignores the partition number', function(done) {
-        exec('ember exam --split 3 --parallel --partition 2 --path acceptance-dist', function(_, stdout) {
-          assert.ok(contains(stdout, 'Ignoring `partition` option due to running split tests in parallel.'), 'lets user know that partition is being ignored');
-          assertAllPartitions(stdout);
+      it('runs multiple specified partitions in parallel', function(done) {
+        exec('ember exam --split 3 --parallel --partition 1 --partition 3 --path acceptance-dist', function(_, stdout) {
+          assertSomePartitions(stdout, [ 1, 3 ], [ 2 ]);
           done();
         });
       });

--- a/node-tests/unit/commands/exam-test.js
+++ b/node-tests/unit/commands/exam-test.js
@@ -51,21 +51,21 @@ describe('ExamCommand', function() {
       });
     });
 
-    it('should set \'partitions\' on the query option with one partition', function() {
+    it('should set \'partition\' on the query option with one partition', function() {
       return command.run({ split: 2, partition: [ 2 ] }).then(function() {
-        assert.equal(called.testRunOptions.query, '_split=2&_partitions=2');
+        assert.equal(called.testRunOptions.query, '_split=2&_partition=2');
       });
     });
 
-    it('should set \'partitions\' on the query option with multiple partitions', function() {
+    it('should set \'partition\' on the query option with multiple partitions', function() {
       return command.run({ split: 2, partition: [ 1, 2 ] }).then(function() {
-        assert.equal(called.testRunOptions.query, '_split=2&_partitions=1,2');
+        assert.equal(called.testRunOptions.query, '_split=2&_partition=1&_partition=2');
       });
     });
 
-    it('should append \'partitions\' to the query option', function() {
+    it('should append \'partition\' to the query option', function() {
       return command.run({ split: 2, partition: [ 2 ], query: 'someQuery=derp&hidepassed' }).then(function() {
-        assert.equal(called.testRunOptions.query, 'someQuery=derp&hidepassed&_split=2&_partitions=2');
+        assert.equal(called.testRunOptions.query, 'someQuery=derp&hidepassed&_split=2&_partition=2');
       });
     });
 
@@ -91,7 +91,7 @@ describe('ExamCommand', function() {
 
     it('should set \'weighted\' on the query option', function() {
       return command.run({ split: 2, partition: [ 2 ], weighted: true }).then(function() {
-        assert.equal(called.testRunOptions.query, '_split=2&_partitions=2&_weighted');
+        assert.equal(called.testRunOptions.query, '_split=2&_partition=2&_weighted');
       });
     });
   });
@@ -124,8 +124,8 @@ describe('ExamCommand', function() {
       });
 
       assert.deepEqual(config.testPage, [
-        "tests/index.html?hidepassed&derp=herp&_split=2&_partitions=1",
-        "tests/index.html?hidepassed&derp=herp&_split=2&_partitions=2"
+        "tests/index.html?hidepassed&derp=herp&_split=2&_partition=1",
+        "tests/index.html?hidepassed&derp=herp&_split=2&_partition=2"
       ]);
     });
 
@@ -137,8 +137,8 @@ describe('ExamCommand', function() {
       });
 
       assert.deepEqual(config.testPage, [
-        "tests/index.html?hidepassed&derp=herp&_split=4&_partitions=3",
-        "tests/index.html?hidepassed&derp=herp&_split=4&_partitions=4"
+        "tests/index.html?hidepassed&derp=herp&_split=4&_partition=3",
+        "tests/index.html?hidepassed&derp=herp&_split=4&_partition=4"
       ]);
     });
 
@@ -150,10 +150,10 @@ describe('ExamCommand', function() {
       });
 
       assert.deepEqual(config.testPage, [
-        "tests/index.html?hidepassed&derp=herp&_split=2&_partitions=1",
-        "tests/index.html?hidepassed&derp=herp&_split=2&_partitions=2",
-        "tests/index.html?hidepassed&foo=bar&_split=2&_partitions=1",
-        "tests/index.html?hidepassed&foo=bar&_split=2&_partitions=2"
+        "tests/index.html?hidepassed&derp=herp&_split=2&_partition=1",
+        "tests/index.html?hidepassed&derp=herp&_split=2&_partition=2",
+        "tests/index.html?hidepassed&foo=bar&_split=2&_partition=1",
+        "tests/index.html?hidepassed&foo=bar&_split=2&_partition=2"
       ]);
     });
 
@@ -166,10 +166,10 @@ describe('ExamCommand', function() {
       });
 
       assert.deepEqual(config.testPage, [
-        "tests/index.html?hidepassed&derp=herp&_split=4&_partitions=3",
-        "tests/index.html?hidepassed&derp=herp&_split=4&_partitions=4",
-        "tests/index.html?hidepassed&foo=bar&_split=4&_partitions=3",
-        "tests/index.html?hidepassed&foo=bar&_split=4&_partitions=4"
+        "tests/index.html?hidepassed&derp=herp&_split=4&_partition=3",
+        "tests/index.html?hidepassed&derp=herp&_split=4&_partition=4",
+        "tests/index.html?hidepassed&foo=bar&_split=4&_partition=3",
+        "tests/index.html?hidepassed&foo=bar&_split=4&_partition=4"
       ]);
     });
 
@@ -191,8 +191,8 @@ describe('ExamCommand', function() {
       });
 
       assert.deepEqual(config.testPage, [
-        "tests.html?foo=bar&_split=2&_partitions=1",
-        "tests.html?foo=bar&_split=2&_partitions=2"
+        "tests.html?foo=bar&_split=2&_partition=1",
+        "tests.html?foo=bar&_split=2&_partition=2"
       ]);
     });
 
@@ -206,8 +206,8 @@ describe('ExamCommand', function() {
       });
 
       assert.deepEqual(config.testPage, [
-        "tests/index.html?hidepassed&_split=2&_partitions=1",
-        "tests/index.html?hidepassed&_split=2&_partitions=2"
+        "tests/index.html?hidepassed&_split=2&_partition=1",
+        "tests/index.html?hidepassed&_split=2&_partition=2"
       ]);
 
       sinon.assert.calledOnce(warnStub);

--- a/node-tests/unit/commands/exam-test.js
+++ b/node-tests/unit/commands/exam-test.js
@@ -51,15 +51,21 @@ describe('ExamCommand', function() {
       });
     });
 
-    it('should set \'partition\' on the query option', function() {
-      return command.run({ split: 2, partition: 2 }).then(function() {
-        assert.equal(called.testRunOptions.query, '_split=2&_partition=2');
+    it('should set \'partitions\' on the query option with one partition', function() {
+      return command.run({ split: 2, partition: [ 2 ] }).then(function() {
+        assert.equal(called.testRunOptions.query, '_split=2&_partitions=2');
       });
     });
 
-    it('should append \'partition\' to the query option', function() {
-      return command.run({ split: 2, partition: 2, query: 'someQuery=derp&hidepassed' }).then(function() {
-        assert.equal(called.testRunOptions.query, 'someQuery=derp&hidepassed&_split=2&_partition=2');
+    it('should set \'partitions\' on the query option with multiple partitions', function() {
+      return command.run({ split: 2, partition: [ 1, 2 ] }).then(function() {
+        assert.equal(called.testRunOptions.query, '_split=2&_partitions=1,2');
+      });
+    });
+
+    it('should append \'partitions\' to the query option', function() {
+      return command.run({ split: 2, partition: [ 2 ], query: 'someQuery=derp&hidepassed' }).then(function() {
+        assert.equal(called.testRunOptions.query, 'someQuery=derp&hidepassed&_split=2&_partitions=2');
       });
     });
 
@@ -84,8 +90,8 @@ describe('ExamCommand', function() {
     });
 
     it('should set \'weighted\' on the query option', function() {
-      return command.run({ split: 2, partition: 2, weighted: true }).then(function() {
-        assert.equal(called.testRunOptions.query, '_split=2&_partition=2&_weighted');
+      return command.run({ split: 2, partition: [ 2 ], weighted: true }).then(function() {
+        assert.equal(called.testRunOptions.query, '_split=2&_partitions=2&_weighted');
       });
     });
   });
@@ -111,19 +117,32 @@ describe('ExamCommand', function() {
       assert.deepEqual(config.testPage, undefined);
     });
 
-    it('should modify the config to have multiple test pages', function() {
+    it('should modify the config to have multiple test pages with no partitions specified', function() {
       var config = generateConfig({
         parallel: true,
         split: 2
       });
 
       assert.deepEqual(config.testPage, [
-        "tests/index.html?hidepassed&derp=herp&_split=2&_partition=1",
-        "tests/index.html?hidepassed&derp=herp&_split=2&_partition=2"
+        "tests/index.html?hidepassed&derp=herp&_split=2&_partitions=1",
+        "tests/index.html?hidepassed&derp=herp&_split=2&_partitions=2"
       ]);
     });
 
-    it('should modify the config to have multiple test pages for each test_page in the config file', function() {
+    it('should modify the config to have multiple test pages with specified partitions', function() {
+      var config = generateConfig({
+        parallel: true,
+        split: 4,
+        partition: [ 3, 4 ]
+      });
+
+      assert.deepEqual(config.testPage, [
+        "tests/index.html?hidepassed&derp=herp&_split=4&_partitions=3",
+        "tests/index.html?hidepassed&derp=herp&_split=4&_partitions=4"
+      ]);
+    });
+
+    it('should modify the config to have multiple test pages for each test_page in the config file with no partitions specified', function() {
       var config = generateConfig({
         parallel: true,
         split: 2,
@@ -131,10 +150,26 @@ describe('ExamCommand', function() {
       });
 
       assert.deepEqual(config.testPage, [
-        "tests/index.html?hidepassed&derp=herp&_split=2&_partition=1",
-        "tests/index.html?hidepassed&derp=herp&_split=2&_partition=2",
-        "tests/index.html?hidepassed&foo=bar&_split=2&_partition=1",
-        "tests/index.html?hidepassed&foo=bar&_split=2&_partition=2"
+        "tests/index.html?hidepassed&derp=herp&_split=2&_partitions=1",
+        "tests/index.html?hidepassed&derp=herp&_split=2&_partitions=2",
+        "tests/index.html?hidepassed&foo=bar&_split=2&_partitions=1",
+        "tests/index.html?hidepassed&foo=bar&_split=2&_partitions=2"
+      ]);
+    });
+
+    it('should modify the config to have multiple test pages for each test_page in the config file with partitions specified', function() {
+      var config = generateConfig({
+        parallel: true,
+        split: 4,
+        partition: [ 3, 4 ],
+        configFile: 'testem.multiple-test-page.js'
+      });
+
+      assert.deepEqual(config.testPage, [
+        "tests/index.html?hidepassed&derp=herp&_split=4&_partitions=3",
+        "tests/index.html?hidepassed&derp=herp&_split=4&_partitions=4",
+        "tests/index.html?hidepassed&foo=bar&_split=4&_partitions=3",
+        "tests/index.html?hidepassed&foo=bar&_split=4&_partitions=4"
       ]);
     });
 
@@ -156,8 +191,8 @@ describe('ExamCommand', function() {
       });
 
       assert.deepEqual(config.testPage, [
-        "tests.html?foo=bar&_split=2&_partition=1",
-        "tests.html?foo=bar&_split=2&_partition=2"
+        "tests.html?foo=bar&_split=2&_partitions=1",
+        "tests.html?foo=bar&_split=2&_partitions=2"
       ]);
     });
 
@@ -171,8 +206,8 @@ describe('ExamCommand', function() {
       });
 
       assert.deepEqual(config.testPage, [
-        "tests/index.html?hidepassed&_split=2&_partition=1",
-        "tests/index.html?hidepassed&_split=2&_partition=2"
+        "tests/index.html?hidepassed&_split=2&_partitions=1",
+        "tests/index.html?hidepassed&_split=2&_partitions=2"
       ]);
 
       sinon.assert.calledOnce(warnStub);

--- a/node-tests/unit/utils/tests-options-validator-test.js
+++ b/node-tests/unit/utils/tests-options-validator-test.js
@@ -27,15 +27,19 @@ describe('TestOptionsValidator', function() {
     });
 
     it('should throw an error if `partition` is used without `split`', function() {
-      shouldSplitThrows({ partition: 1 }, /You must specify a 'split' value in order to use 'partition'/);
+      shouldSplitThrows({ partition: [1] }, /You must specify a 'split' value in order to use 'partition'/);
     });
 
-    it('should throw an error if `partition` is less than 1', function() {
-      shouldSplitThrows({ split: 2, partition: 0 }, /Split tests are one-indexed, so you must specify a partition greater than or equal to 1/);
+    it('should throw an error if `partition` contains a value less than 1', function() {
+      shouldSplitThrows({ split: 2, partition: [1, 0] }, /Split tests are one-indexed, so you must specify partition values greater than or equal to 1./);
     });
 
-    it('should throw an error if `partition` is greater than `split`', function() {
-      shouldSplitThrows({ split: 2, partition: 3 }, /You must specify a 'partition' value that is less than or equal to your 'split' value/);
+    it('should throw an error if `partition` contains a value greater than `split`', function() {
+      shouldSplitThrows({ split: 2, partition: [1, 3] }, /You must specify 'partition' values that are less than or equal to your 'split' value./);
+    });
+
+    it('should throw an error if `partition` contains duplicate values', function() {
+      shouldSplitThrows({ split: 2, partition: [1, 2, 1] }, /You cannot specify the same partition twice./);
     });
 
     it('should throw an error if `weighted` is being used without `split`', function() {
@@ -47,7 +51,7 @@ describe('TestOptionsValidator', function() {
     });
 
     it('should return true if using `split` and `partition`', function() {
-      shouldSplitEqual({ split: 2, partition: 1 }, true);
+      shouldSplitEqual({ split: 2, partition: [1] }, true);
     });
 
     it('should return false if not using `split`', function() {
@@ -79,20 +83,6 @@ describe('TestOptionsValidator', function() {
   describe('shouldParallelize', function() {
     it('should throw an error if `split` is not being used', function() {
       shouldThrow('Parallelize', { parallel: true }, /You must specify the `split` option in order to run your tests in parallel/);
-    });
-
-    it('should log a message about ignoring the `partition` option', function() {
-      var lastLog = '';
-      var originalLog = console.info;
-      console.info = function(str) {
-        lastLog = str;
-      };
-
-      var validator = new TestOptionsValidator({ split: 2, partition: 1, parallel: true });
-      assert.equal(validator.shouldParallelize, true);
-      assert.equal(lastLog, 'Ignoring `partition` option due to running split tests in parallel.');
-
-      console.info = originalLog;
     });
 
     it('should return false', function() {

--- a/tests/unit/test-loader-test.js
+++ b/tests/unit/test-loader-test.js
@@ -48,7 +48,7 @@ test('loads all test modules by default', function(assert) {
 
 test('loads modules from a specified partition', function(assert) {
   QUnit.urlParams = {
-    _partitions: 3,
+    _partition: 3,
     _split: 4,
   };
 
@@ -62,7 +62,7 @@ test('loads modules from a specified partition', function(assert) {
 
 test('loads modules from multiple specified partitions', function(assert) {
   QUnit.urlParams = {
-    _partitions: '1,3',
+    _partition: [1, 3],
     _split: 4,
   };
 
@@ -91,7 +91,7 @@ test('loads modules from the first partition by default', function(assert) {
 
 test('handles params as strings', function(assert) {
   QUnit.urlParams = {
-    _partitions: '3',
+    _partition: '3',
     _split: '4',
   };
 
@@ -116,29 +116,29 @@ test('throws an error if splitting less than one', function(assert) {
 test('throws an error if partition isn\'t a number', function(assert) {
   QUnit.urlParams = {
     _split: 2,
-    _partitions: "foo",
+    _partition: "foo",
   };
 
   assert.throws(() => {
     this.TestLoader.load();
-  }, /You must specify numbers for partitions \(you specified 'foo'\)/);
+  }, /You must specify numbers for partition \(you specified 'foo'\)/);
 });
 
 test('throws an error if partition isn\'t a number with multiple partitions', function(assert) {
   QUnit.urlParams = {
     _split: 2,
-    _partitions: "1,foo",
+    _partition: [1, "foo"],
   };
 
   assert.throws(() => {
     this.TestLoader.load();
-  }, /You must specify numbers for partitions \(you specified '1,foo'\)/);
+  }, /You must specify numbers for partition \(you specified '1,foo'\)/);
 });
 
 test('throws an error if loading partition greater than split number', function(assert) {
   QUnit.urlParams = {
     _split: 2,
-    _partitions: 3,
+    _partition: 3,
   };
 
   assert.throws(() => {
@@ -149,7 +149,7 @@ test('throws an error if loading partition greater than split number', function(
 test('throws an error if loading partition greater than split number with multiple partitions', function(assert) {
   QUnit.urlParams = {
     _split: 2,
-    _partitions: '2,3',
+    _partition: [2, 3],
   };
 
   assert.throws(() => {
@@ -160,7 +160,7 @@ test('throws an error if loading partition greater than split number with multip
 test('throws an error if loading partition less than one', function(assert) {
   QUnit.urlParams = {
     _split: 2,
-    _partitions: 0,
+    _partition: 0,
   };
 
   assert.throws(() => {
@@ -171,7 +171,7 @@ test('throws an error if loading partition less than one', function(assert) {
 test('load works without lint tests', function(assert) {
   QUnit.urlParams = {
     nolint: true,
-    _partitions: 4,
+    _partition: 4,
     _split: 4,
   };
 
@@ -191,7 +191,7 @@ test('load works without non-lint tests', function(assert) {
   };
 
   QUnit.urlParams = {
-    _partitions: 4,
+    _partition: 4,
     _split: 4,
   };
 

--- a/tests/unit/test-loader-test.js
+++ b/tests/unit/test-loader-test.js
@@ -48,13 +48,29 @@ test('loads all test modules by default', function(assert) {
 
 test('loads modules from a specified partition', function(assert) {
   QUnit.urlParams = {
-    _partition: 3,
+    _partitions: 3,
     _split: 4,
   };
 
   this.TestLoader.load();
 
   assert.deepEqual(this.requiredModules, [
+    'test-3-test.jshint',
+    'test-3-test',
+  ]);
+});
+
+test('loads modules from multiple specified partitions', function(assert) {
+  QUnit.urlParams = {
+    _partitions: '1,3',
+    _split: 4,
+  };
+
+  this.TestLoader.load();
+
+  assert.deepEqual(this.requiredModules, [
+    'test-1-test.jshint',
+    'test-1-test',
     'test-3-test.jshint',
     'test-3-test',
   ]);
@@ -75,7 +91,7 @@ test('loads modules from the first partition by default', function(assert) {
 
 test('handles params as strings', function(assert) {
   QUnit.urlParams = {
-    _partition: '3',
+    _partitions: '3',
     _split: '4',
   };
 
@@ -97,32 +113,65 @@ test('throws an error if splitting less than one', function(assert) {
   }, /You must specify a split greater than 0/);
 });
 
-test('throws an error if loading partition greater than split number', function(assert) {
+test('throws an error if partition isn\'t a number', function(assert) {
   QUnit.urlParams = {
     _split: 2,
-    _partition: 3,
+    _partitions: "foo",
   };
 
   assert.throws(() => {
     this.TestLoader.load();
-  }, /You must specify a partition less than or equal to your split value/);
+  }, /You must specify numbers for partitions \(you specified 'foo'\)/);
+});
+
+test('throws an error if partition isn\'t a number with multiple partitions', function(assert) {
+  QUnit.urlParams = {
+    _split: 2,
+    _partitions: "1,foo",
+  };
+
+  assert.throws(() => {
+    this.TestLoader.load();
+  }, /You must specify numbers for partitions \(you specified '1,foo'\)/);
+});
+
+test('throws an error if loading partition greater than split number', function(assert) {
+  QUnit.urlParams = {
+    _split: 2,
+    _partitions: 3,
+  };
+
+  assert.throws(() => {
+    this.TestLoader.load();
+  }, /You must specify partitions numbered less than or equal to your split value/);
+});
+
+test('throws an error if loading partition greater than split number with multiple partitions', function(assert) {
+  QUnit.urlParams = {
+    _split: 2,
+    _partitions: '2,3',
+  };
+
+  assert.throws(() => {
+    this.TestLoader.load();
+  }, /You must specify partitions numbered less than or equal to your split value/);
 });
 
 test('throws an error if loading partition less than one', function(assert) {
   QUnit.urlParams = {
     _split: 2,
-    _partition: 0,
+    _partitions: 0,
   };
 
   assert.throws(() => {
     this.TestLoader.load();
-  }, /You must specify a partition greater than 0/);
+  }, /You must specify partitions numbered greater than 0/);
 });
 
 test('load works without lint tests', function(assert) {
   QUnit.urlParams = {
     nolint: true,
-    _partition: 4,
+    _partitions: 4,
     _split: 4,
   };
 
@@ -142,7 +191,7 @@ test('load works without non-lint tests', function(assert) {
   };
 
   QUnit.urlParams = {
-    _partition: 4,
+    _partitions: 4,
     _split: 4,
   };
 

--- a/vendor/ember-exam/test-loader.js
+++ b/vendor/ember-exam/test-loader.js
@@ -82,8 +82,9 @@ jQuery(document).ready(function() {
       }
 
       var group = partition - 1;
-      tests = tests.concat(lintTestGroups[group]).concat(otherTestGroups[group]);
+      tests = tests.concat(lintTestGroups[group], otherTestGroups[group]);
     }
+
     return tests;
   }
 

--- a/vendor/ember-exam/test-loader.js
+++ b/vendor/ember-exam/test-loader.js
@@ -6,7 +6,7 @@ jQuery(document).ready(function() {
     Testem.on('test-result', function prependPartition(test) {
       var split = QUnit.urlParams._split;
       if (split) {
-        test.name = 'Exam Partition #' + (QUnit.urlParams._partitions || 1) + ' - ' + test.name;
+        test.name = 'Exam Partition #' + (QUnit.urlParams._partition || 1) + ' - ' + test.name;
       }
     });
   }
@@ -37,15 +37,14 @@ jQuery(document).ready(function() {
   TestLoader.prototype.loadModules = function _loadSplitModules() {
     var params = QUnit.urlParams;
     var split = parseInt(params._split, 10);
-    var partitions = params._partitions;
+    var partitions = params._partition;
 
     split = isNaN(split) ? 1 : split;
 
-    if (typeof partitions === 'string') {
-      partitions = partitions.split(',');
-    } else {
-      partitions = parseInt(partitions, 10);
-      partitions = [isNaN(partitions) ? 1 : partitions];
+    if (partitions === undefined) {
+      partitions = [1];
+    } else if (typeof partitions === 'number') {
+      partitions = [partitions];
     }
 
     var testLoader = this;
@@ -73,7 +72,7 @@ jQuery(document).ready(function() {
     for (var i = 0; i < partitions.length; i++) {
       var partition = parseInt(partitions[i], 10);
       if (isNaN(partition)) {
-        throw new Error('You must specify numbers for partitions (you specified \'' + partitions + '\')');
+        throw new Error('You must specify numbers for partition (you specified \'' + partitions + '\')');
       }
 
       if (split < partition) {


### PR DESCRIPTION
The primary use case is splitting test modules across multiple CI containers, and having each of those CI containers run its list of tests in multiple parallel runs (you would specify split, parallel, and multiple partitions for each container). This can also be used for unbalanced partitioning, e.g. if you want one container to run 2/3 of the tests and the other run 1/3 (you would specify split and then different numbers of partitions for different containers).

Fixes #62 
