### PR TITLE
Fixed issue using a single partition with a double digit number

### DIFF
--- a/node-tests/acceptance/exam-test.js
+++ b/node-tests/acceptance/exam-test.js
@@ -11,7 +11,7 @@ function getNumberOfTests(str) {
   return match ? parseInt(match[1], 10) : 0;
 }
 
-var TOTAL_NUM_TESTS = 44;
+var TOTAL_NUM_TESTS = 45;
 
 describe('Acceptance | Exam Command', function() {
   this.timeout(300000);

--- a/tests/unit/test-loader-test.js
+++ b/tests/unit/test-loader-test.js
@@ -201,3 +201,29 @@ test('load works without non-lint tests', function(assert) {
     'test-4-test.jshint',
   ]);
 });
+
+test('load works with a double-digit single partition', function(assert) {
+  window.requirejs.entries = {
+    'test-1-test': true,
+    'test-2-test': true,
+    'test-3-test': true,
+    'test-4-test': true,
+    'test-5-test': true,
+    'test-6-test': true,
+    'test-7-test': true,
+    'test-8-test': true,
+    'test-9-test': true,
+    'test-10-test': true,
+  };
+
+  QUnit.urlParams = {
+    _partition: '10',
+    _split: 10,
+  };
+
+  this.TestLoader.load();
+
+  assert.deepEqual(this.requiredModules, [
+    'test-10-test',
+  ]);
+});

--- a/vendor/ember-exam/test-loader.js
+++ b/vendor/ember-exam/test-loader.js
@@ -43,7 +43,7 @@ jQuery(document).ready(function() {
 
     if (partitions === undefined) {
       partitions = [1];
-    } else if (typeof partitions === 'number') {
+    } else if (!Array.isArray(partitions)) {
       partitions = [partitions];
     }
 


### PR DESCRIPTION
If you have a command like `ember exam --split=10 --partition=10`, the command fails to run with a `You must specify partitions numbered greater than 0` error.

This is because `10` is been treated as a string when we get to https://github.com/trentmwillis/ember-exam/blob/master/vendor/ember-exam/test-loader.js#L72 and we try to loop over the number a digit at a time, i.e. first "1" and then "0"