### PR TITLE
Document "gotcha" for `random`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ $ ember exam --random=this_is1337
 $ Randomizing tests with seed: this_is1337
 ```
 
+If you use `random` without specifying a seed, it must be the last argument you pass. Otherwise, Ember Exam will attempt to interpret any following arguments as the seed value. In other words:
+
+```bash
+# don't do this
+ember exam --random --split=2
+Randomizing tests with seed: --split=2 # this is not what we wanted
+
+# do this instead
+ember exam --split=2 --random
+Randomizing tests with seed: hwr74nkk55vzpvi
+```
+
 _Note: You must be using QUnit version `1.23.0` or greater for this feature to work properly. This feature is not currently supported by Mocha._
 
 #### Randomization Iterator

--- a/lib/commands/exam.js
+++ b/lib/commands/exam.js
@@ -111,7 +111,7 @@ module.exports = TestCommand.extend({
   _randomize: function(random, query) {
     var seed = random !== '' ? random : Math.random().toString(36).slice(2);
 
-    this.ui.writeLine('Randomizing test with seed: ' + seed);
+    this.ui.writeLine('Randomizing tests with seed: ' + seed);
 
     return addToQuery(query, 'seed', seed);
   },

--- a/node-tests/acceptance/exam-iterate-test.js
+++ b/node-tests/acceptance/exam-iterate-test.js
@@ -21,7 +21,7 @@ describe('Acceptance | Exam Iterate Command', function() {
       assert.ok(contains(stdout, 'Running iteration #1.'), 'Logs first iteration');
       assert.ok(contains(stdout, 'Running iteration #2.'), 'Logs second iteration');
 
-      var seedRE = /Randomizing test with seed: (.*)/g;
+      var seedRE = /Randomizing tests with seed: (.*)/g;
 
       var firstSeed = seedRE.exec(stdout)[1];
       var secondSeed = seedRE.exec(stdout)[1];
@@ -65,7 +65,7 @@ describe('Acceptance | Exam Iterate Command', function() {
       assert.ok(contains(stdout, 'Running iteration #1.'), 'Logs first iteration');
       assert.ok(contains(stdout, 'Running iteration #2.'), 'Logs second iteration');
 
-      var seedRE = /Randomizing test with seed: (.*)/g;
+      var seedRE = /Randomizing tests with seed: (.*)/g;
 
       var firstSeed = seedRE.exec(stdout)[1];
       var secondSeed = seedRE.exec(stdout)[1];

--- a/node-tests/acceptance/exam-test.js
+++ b/node-tests/acceptance/exam-test.js
@@ -123,7 +123,7 @@ describe('Acceptance | Exam Command', function() {
   describe('Random', function() {
     it('runs tests with the passed in seeds', function(done) {
       exec('ember exam --random 1337 --path acceptance-dist', function(_, stdout) {
-        assert.ok(contains(stdout, 'Randomizing test with seed: 1337'), 'logged the seed value');
+        assert.ok(contains(stdout, 'Randomizing tests with seed: 1337'), 'logged the seed value');
         assert.equal(getNumberOfTests(stdout), TOTAL_NUM_TESTS, 'ran all of the tests in the suite');
         done();
       });


### PR DESCRIPTION
Adds a note about #73 and fixes the grammar of the seed logging message.