### PR TITLE
Add Node LTS versions to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 ---
 language: node_js
 node_js:
-  - "0.12"
   - "4"
   - "6"
   - "stable"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,8 @@ cache:
     - node_modules
 
 env:
-  - TEST_FRAMEWORK=ember-cli-qunit EMBER_TRY_SCENARIO=default
-  - TEST_FRAMEWORK=ember-cli-qunit EMBER_TRY_SCENARIO=ember-release
-  - TEST_FRAMEWORK=ember-cli-qunit EMBER_TRY_SCENARIO=ember-beta
-  - TEST_FRAMEWORK=ember-cli-qunit EMBER_TRY_SCENARIO=ember-canary
-  - TEST_FRAMEWORK=ember-cli-mocha EMBER_TRY_SCENARIO=default
-  - TEST_FRAMEWORK=ember-cli-mocha EMBER_TRY_SCENARIO=ember-release
-  - TEST_FRAMEWORK=ember-cli-mocha EMBER_TRY_SCENARIO=ember-beta
-  - TEST_FRAMEWORK=ember-cli-mocha EMBER_TRY_SCENARIO=ember-canary
+  - TEST_FRAMEWORK=ember-cli-qunit
+  - TEST_FRAMEWORK=ember-cli-mocha
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@
 language: node_js
 node_js:
   - "0.12"
+  - "4"
+  - "6"
+  - "stable"
 
 sudo: false
 

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "test": "mocha 'node-tests/**/*-test.js'",
     "test:ember": "ember try:each",
     "test:all": "npm run test:ember && npm test",
-    "test:ci": "ember try:one $EMBER_TRY_SCENARIO && npm test",
+    "test:ci": "ember try:each && npm test",
     "test:cover": "istanbul cover ./node_modules/mocha/bin/_mocha -- 'node-tests/**/*-test.js'",
-    "test:ci:cover": "ember try:one $EMBER_TRY_SCENARIO && npm run test:cover"
+    "test:ci:cover": "ember try:each && npm run test:cover"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
@trentmwillis Seems like it would be good for Travis to be running against the current Node LTS versions ([currently 4.x and 6.x](https://github.com/nodejs/LTS)).

Additionally, since Node 0.12 was EOL'ed last year, I removed that.

For what it's worth, I see test failures locally when running master against Node 4.7.2 so I'm curious if those failures will surface in Travis as well.

Happy to adjust the PR if you have any feedback.